### PR TITLE
proposed name changes to several types for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In Owl Ode, We support a number of natively-implemented double-precision solvers
 The simple example above illustrates the basic components of defining and solving an ode problem using Owl Ode.
 The main function `Owl_ode.odeint` takes as its arguments:
 
-- a solver module of type `SolverT`, 
+- a solver module of type `Solver`, 
 - a function `f` that evolves the state,
 - an initial state `x0`, and
 - temporal spsecification `tspec`.
@@ -84,7 +84,7 @@ We also support temporal integration of matrices.  That is, cases in which the s
 
 ### Custom Solvers
 
-We can define new solver module by creating a module of type `SolverT`. For example, to create a custom Cvode solver that has a relative tolerance of 1E-7 as opposed to the default 1E-4, we can define and use `custom_cvode` as follows:
+We can define new solver module by creating a module of type `Solver`. For example, to create a custom Cvode solver that has a relative tolerance of 1E-7 as opposed to the default 1E-4, we can define and use `custom_cvode` as follows:
 
 ```ocaml
 let custom_cvode = Owl_ode_sundials.cvode ~stiff:false ~relative_tol:1E-7 ~abs_tol:1E-4 
@@ -95,11 +95,11 @@ let ts, xs = Owl_ode.odeint custom_cvode f x0 tspec ()
 Here, we use the `cvode` function construct a solver module `Custom_Owl_Cvode`. This function is conveniently defined in `src/sundials/owl_ode_sundials.ml`. It takes the parameters (`stiff`, `relative_tol`, and `abs_tol`) and returns a solver module of type 
 
 ```ocaml
-val custom_cvode : (module SolverT with 
-                     type s = Mat.mat
-                     and type t = Mat.mat
+val custom_cvode : (module Solver with 
+                     type state = Mat.mat
+                     and type f = Mat.mat -> float -> Mat.mat
                      and type step_output = Mat.mat * float
-                     and type output = Mat.mat * Mat.mat)
+                     and type solve_output = Mat.mat * Mat.mat)
 ```
 
 Similar helper functions like `cvode` have been also defined for native and symplectic solvers.

--- a/src/ode/native/native_d.ml
+++ b/src/ode/native/native_d.ml
@@ -11,50 +11,50 @@ type mat = Owl_dense_matrix_d.mat
 include Native_generic.Make (Owl_dense_ndarray.D)
 
 module Euler = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = euler_s
   let solve = prepare step
 end
 
 module Midpoint = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = midpoint_s
   let solve = prepare step
 end
 
 module RK4 = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = rk4_s
   let solve = prepare step
 end
 
 module RK23 = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float * float * bool
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = rk23_s ~tol:1e-7 ~dtmax:1E-4
   let solve = adaptive_prepare (rk23_s ~tol:1E-7)
 end
 
 module RK45 = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float * float * bool
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = rk45_s ~tol:1e-7 ~dtmax:1E-4
   let solve = adaptive_prepare (rk45_s ~tol:1E-7)

--- a/src/ode/native/native_d.mli
+++ b/src/ode/native/native_d.mli
@@ -9,79 +9,79 @@
 type mat = Owl_dense_matrix_d.mat
 
 module Euler :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 module Midpoint :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 module RK4 :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 (** Default tol = 1e-7 *)
 module RK23 :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float * float * bool
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 module RK45 :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float * float * bool
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 val euler
-  : (module Types.SolverT
-       with type s = mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat
+        and type f = mat -> float -> mat
         and type step_output = mat * float
-        and type output = mat * mat)
+        and type solve_output = mat * mat)
 
 val midpoint
-  : (module Types.SolverT
-       with type s = mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat
+        and type f = mat -> float -> mat
         and type step_output = mat * float
-        and type output = mat * mat)
+        and type solve_output = mat * mat)
 
 val rk4
-  : (module Types.SolverT
-       with type s = mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat
+        and type f = mat -> float -> mat
         and type step_output = mat * float
-        and type output = mat * mat)
+        and type solve_output = mat * mat)
 
 val rk23
   :  tol:float
   -> dtmax:float
-  -> (module Types.SolverT
-        with type s = mat
-         and type t = mat
+  -> (module Types.Solver
+        with type state = mat
+         and type f = mat -> float -> mat
          and type step_output = mat * float * float * bool
-         and type output = mat * mat)
+         and type solve_output = mat * mat)
 
 val rk45
   :  tol:float
   -> dtmax:float
-  -> (module Types.SolverT
-        with type s = mat
-         and type t = mat
+  -> (module Types.Solver
+        with type state = mat
+         and type f = mat -> float -> mat
          and type step_output = mat * float * float * bool
-         and type output = mat * mat)
+         and type solve_output = mat * mat)
 
 (* ----- helper function ----- *)
 

--- a/src/ode/native/native_generic.ml
+++ b/src/ode/native/native_generic.ml
@@ -54,19 +54,19 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) = struct
 
   let euler =
     (module struct
-      type s = M.arr
-      type t = M.arr
+      type state = M.arr
+      type f = M.arr -> float -> M.arr
       type step_output = M.arr * float
-      type output = M.arr * M.arr
+      type solve_output = M.arr * M.arr
 
       let step = euler_s
       let solve = prepare step
     end
-    : SolverT
-      with type s = M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr
+       and type f = M.arr -> float -> M.arr
        and type step_output = M.arr * float
-       and type output = M.arr * M.arr)
+       and type solve_output = M.arr * M.arr)
 
 
   let midpoint_s (f : f_t) ~dt y0 t0 =
@@ -79,19 +79,19 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) = struct
 
   let midpoint =
     (module struct
-      type s = M.arr
-      type t = M.arr
+      type state = M.arr
+      type f = M.arr -> float -> M.arr
       type step_output = M.arr * float
-      type output = M.arr * M.arr
+      type solve_output = M.arr * M.arr
 
       let step = midpoint_s
       let solve = prepare step
     end
-    : SolverT
-      with type s = M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr
+       and type f = M.arr -> float -> M.arr
        and type step_output = M.arr * float
-       and type output = M.arr * M.arr)
+       and type solve_output = M.arr * M.arr)
 
 
   let rk4_s (f : f_t) ~dt y0 t0 =
@@ -107,19 +107,19 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) = struct
 
   let rk4 =
     (module struct
-      type s = M.arr
-      type t = M.arr
+      type state = M.arr
+      type f = M.arr -> float -> M.arr
       type step_output = M.arr * float
-      type output = M.arr * M.arr
+      type solve_output = M.arr * M.arr
 
       let step = rk4_s
       let solve = prepare step
     end
-    : SolverT
-      with type s = M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr
+       and type f = M.arr -> float -> M.arr
        and type step_output = M.arr * float
-       and type output = M.arr * M.arr)
+       and type solve_output = M.arr * M.arr)
 
 
   let rk23_s ~tol ~dtmax f =
@@ -159,19 +159,19 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) = struct
 
   let rk23 ~tol ~dtmax =
     (module struct
-      type s = M.arr
-      type t = M.arr
+      type state = M.arr
+      type f = M.arr -> float -> M.arr
       type step_output = M.arr * float * float * bool
-      type output = M.arr * M.arr
+      type solve_output = M.arr * M.arr
 
       let step = rk23_s ~tol ~dtmax
       let solve = adaptive_prepare (rk23_s ~tol)
     end
-    : SolverT
-      with type s = M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr
+       and type f = M.arr -> float -> M.arr
        and type step_output = M.arr * float * float * bool
-       and type output = M.arr * M.arr)
+       and type solve_output = M.arr * M.arr)
 
 
   let rk45_s ~tol ~dtmax f =
@@ -276,19 +276,19 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) = struct
 
   let rk45 ~tol ~dtmax =
     (module struct
-      type s = M.arr
-      type t = M.arr
+      type state = M.arr
+      type f = M.arr -> float -> M.arr
       type step_output = M.arr * float * float * bool
-      type output = M.arr * M.arr
+      type solve_output = M.arr * M.arr
 
       let step = rk45_s ~tol ~dtmax
       let solve = adaptive_prepare (rk45_s ~tol)
     end
-    : SolverT
-      with type s = M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr
+       and type f = M.arr -> float -> M.arr
        and type step_output = M.arr * float * float * bool
-       and type output = M.arr * M.arr)
+       and type solve_output = M.arr * M.arr)
 
 
   (* ----- helper functions ----- *)

--- a/src/ode/native/native_generic.mli
+++ b/src/ode/native/native_generic.mli
@@ -15,7 +15,7 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) : sig
     :  ('a -> dt:float -> M.arr -> float -> M.arr * float)
     -> 'a
     -> M.arr
-    -> tspec_t
+    -> tspec
     -> unit
     -> M.arr * M.arr
 
@@ -23,7 +23,7 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) : sig
     :  (dtmax:float -> 'a -> dt:float -> M.arr -> float -> M.arr * float * float * bool)
     -> 'a
     -> M.arr
-    -> tspec_t
+    -> tspec
     -> unit
     -> M.arr * M.arr
 
@@ -50,43 +50,43 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) : sig
     -> M.arr * float * float * bool
 
   val euler
-    : (module Types.SolverT
-         with type s = M.arr
-          and type t = M.arr
+    : (module Types.Solver
+         with type state = M.arr
+          and type f = M.arr -> float -> M.arr
           and type step_output = M.arr * float
-          and type output = M.arr * M.arr)
+          and type solve_output = M.arr * M.arr)
 
   val midpoint
-    : (module Types.SolverT
-         with type s = M.arr
-          and type t = M.arr
+    : (module Types.Solver
+         with type state = M.arr
+          and type f = M.arr -> float -> M.arr
           and type step_output = M.arr * float
-          and type output = M.arr * M.arr)
+          and type solve_output = M.arr * M.arr)
 
   val rk4
-    : (module Types.SolverT
-         with type s = M.arr
-          and type t = M.arr
+    : (module Types.Solver
+         with type state = M.arr
+          and type f = M.arr -> float -> M.arr
           and type step_output = M.arr * float
-          and type output = M.arr * M.arr)
+          and type solve_output = M.arr * M.arr)
 
   val rk23
     :  tol:float
     -> dtmax:float
-    -> (module Types.SolverT
-          with type s = M.arr
-           and type t = M.arr
+    -> (module Types.Solver
+          with type state = M.arr
+           and type f = M.arr -> float -> M.arr
            and type step_output = M.arr * float * float * bool
-           and type output = M.arr * M.arr)
+           and type solve_output = M.arr * M.arr)
 
   val rk45
     :  tol:float
     -> dtmax:float
-    -> (module SolverT
-          with type s = M.arr
-           and type t = M.arr
+    -> (module Solver
+          with type state = M.arr
+           and type f = M.arr -> float -> M.arr
            and type step_output = M.arr * float * float * bool
-           and type output = M.arr * M.arr)
+           and type solve_output = M.arr * M.arr)
 
   (* ----- helper functions ----- *)
 

--- a/src/ode/native/native_s.ml
+++ b/src/ode/native/native_s.ml
@@ -11,50 +11,50 @@ type mat = Owl_dense_matrix_s.mat
 include Native_generic.Make (Owl_dense_ndarray.S)
 
 module Euler = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = euler_s
   let solve = prepare step
 end
 
 module Midpoint = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = midpoint_s
   let solve = prepare step
 end
 
 module RK4 = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = rk4_s
   let solve = prepare step
 end
 
 module RK23 = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float * float * bool
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = rk23_s ~tol:1E-7 ~dtmax:1E-4
   let solve = adaptive_prepare (rk23_s ~tol:1E-7)
 end
 
 module RK45 = struct
-  type s = mat
-  type t = mat
+  type state = mat
+  type f = mat -> float -> mat
   type step_output = mat * float * float * bool
-  type output = mat * mat
+  type solve_output = mat * mat
 
   let step = rk45_s ~tol:1e-7 ~dtmax:1E-4
   let solve = adaptive_prepare (rk45_s ~tol:1E-7)

--- a/src/ode/native/native_s.mli
+++ b/src/ode/native/native_s.mli
@@ -9,79 +9,79 @@
 type mat = Owl_dense_matrix_s.mat
 
 module Euler :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 module Midpoint :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 module RK4 :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 (** Default tol = 1e-7 *)
 module RK23 :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float * float * bool
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 module RK45 :
-  Types.SolverT
-  with type s = mat
-   and type t = mat
+  Types.Solver
+  with type state = mat
+   and type f = mat -> float -> mat
    and type step_output = mat * float * float * bool
-   and type output = mat * mat
+   and type solve_output = mat * mat
 
 val euler
-  : (module Types.SolverT
-       with type s = mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat
+        and type f = mat -> float -> mat
         and type step_output = mat * float
-        and type output = mat * mat)
+        and type solve_output = mat * mat)
 
 val midpoint
-  : (module Types.SolverT
-       with type s = mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat
+        and type f = mat -> float -> mat
         and type step_output = mat * float
-        and type output = mat * mat)
+        and type solve_output = mat * mat)
 
 val rk4
-  : (module Types.SolverT
-       with type s = mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat
+        and type f = mat -> float -> mat
         and type step_output = mat * float
-        and type output = mat * mat)
+        and type solve_output = mat * mat)
 
 val rk23
   :  tol:float
   -> dtmax:float
-  -> (module Types.SolverT
-        with type s = mat
-         and type t = mat
+  -> (module Types.Solver
+        with type state = mat
+         and type f = mat -> float -> mat
          and type step_output = mat * float * float * bool
-         and type output = mat * mat)
+         and type solve_output = mat * mat)
 
 val rk45
   :  tol:float
   -> dtmax:float
-  -> (module Types.SolverT
-        with type s = mat
-         and type t = mat
+  -> (module Types.Solver
+        with type state = mat
+         and type f = mat -> float -> mat
          and type step_output = mat * float * float * bool
-         and type output = mat * mat)
+         and type solve_output = mat * mat)
 
 (* ----- helper function ----- *)
 

--- a/src/ode/ode.ml
+++ b/src/ode/ode.ml
@@ -10,14 +10,14 @@ open Types
 
 let step
     (type a b c d)
-    (module Solver : SolverT
-      with type output = a
-       and type s = b
-       and type step_output = c
-       and type t = d)
-    (f : b -> float -> d)
+    (module Solver : Solver
+      with type f = a
+       and type solve_output = b
+       and type state = c
+       and type step_output = d)
+    (f : a)
     ~(dt : float)
-    (y0 : b)
+    (y0 : c)
     (t0 : float)
   =
   Solver.step f ~dt y0 t0
@@ -25,13 +25,13 @@ let step
 
 let odeint
     (type a b c d)
-    (module Solver : SolverT
-      with type output = a
-       and type s = b
-       and type step_output = c
-       and type t = d)
-    (f : b -> float -> d)
-    (y0 : b)
-    (tspec : tspec_t)
+    (module Solver : Solver
+      with type f = a
+       and type solve_output = b
+       and type state = c
+       and type step_output = d)
+    (f : a)
+    (y0 : c)
+    (tspec : tspec)
   =
   Solver.solve f y0 tspec

--- a/src/ode/ode.mli
+++ b/src/ode/ode.mli
@@ -13,16 +13,16 @@
     output of type step_output.
 *)
 val step
-  :  (module Types.SolverT
-        with type output = 'a
-         and type s = 'b
-         and type step_output = 'c
-         and type t = 'd)
-  -> ('b -> float -> 'd)
+  :  (module Types.Solver
+        with type f = 'a
+         and type solve_output = 'b
+         and type state = 'c
+         and type step_output = 'd)
+  -> 'a
   -> dt:float
-  -> 'b
-  -> float
   -> 'c
+  -> float
+  -> 'd
 
 (** [odeint (module Solver) f y0 timespec ()] numerically integrates
     an initial value problem for a system of ODEs given an initial value:
@@ -38,24 +38,24 @@ val step
     The goal is to find y(t) approximately satisfying the differential
     equations, given an initial value y(t₀)=y₀. The time t₀ is passed as
     part of the timespec, that includes also the final integration time
-    and a time step. Refer to {!Owl_ode.Types.tspec_t} for further
+    and a time step. Refer to {!Owl_ode.Types.tspec} for further
     information.
 
     The solver has to be passed as a first-class module and have a common
-    type, {!Owl_ode.Types.SolverT}. This is useful to write new custom
+    type, {!Owl_ode.Types.Solver}. This is useful to write new custom
     solvers or extend and customise the provided ones.
  
-    Refer to the documentation of the {!Owl_ode.Types.SolverT} type 
+    Refer to the documentation of the {!Owl_ode.Types.Solver} type 
     for further information.
 *)
 val odeint
-  :  (module Types.SolverT
-        with type output = 'a
-         and type s = 'b
-         and type step_output = 'c
-         and type t = 'd)
-  -> ('b -> float -> 'd)
-  -> 'b
-  -> Types.tspec_t
-  -> unit
+  :  (module Types.Solver
+        with type f = 'a
+         and type solve_output = 'b
+         and type state = 'c
+         and type step_output = 'd)
   -> 'a
+  -> 'c
+  -> Types.tspec
+  -> unit
+  -> 'b

--- a/src/ode/symplectic/symplectic_d.ml
+++ b/src/ode/symplectic/symplectic_d.ml
@@ -11,50 +11,50 @@ type mat = Owl_dense_matrix_d.mat
 include Symplectic_generic.Make (Owl_dense_ndarray.D)
 
 module Symplectic_Euler = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = symplectic_euler_s
   let solve = prepare step
 end
 
 module PseudoLeapfrog = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = pseudoleapfrog_s
   let solve = prepare step
 end
 
 module Leapfrog = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = leapfrog_s
   let solve = prepare step
 end
 
 module Ruth3 = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = ruth3_s
   let solve = prepare step
 end
 
 module Ruth4 = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = ruth4_s
   let solve = prepare step

--- a/src/ode/symplectic/symplectic_d.mli
+++ b/src/ode/symplectic/symplectic_d.mli
@@ -9,74 +9,74 @@
 type mat = Owl_dense_matrix_d.mat
 
 module Symplectic_Euler :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 module PseudoLeapfrog :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 module Leapfrog :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 module Ruth3 :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 module Ruth4 :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 val symplectic_euler
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 val leapfrog
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 val pseudoleapfrog
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 val ruth3
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 val ruth4
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 (* ----- helper function ----- *)
 

--- a/src/ode/symplectic/symplectic_generic.ml
+++ b/src/ode/symplectic/symplectic_generic.ml
@@ -42,19 +42,19 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) = struct
 
   let symplectic_euler =
     (module struct
-      type s = M.arr * M.arr
-      type t = M.arr
+      type state = M.arr * M.arr
+      type f = M.arr * M.arr -> float -> M.arr
       type step_output = (M.arr * M.arr) * float
-      type output = M.arr * M.arr * M.arr
+      type solve_output = M.arr * M.arr * M.arr
 
       let step = symplectic_euler_s
       let solve = prepare step
     end
-    : SolverT
-      with type s = M.arr * M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr * M.arr
+       and type f = M.arr * M.arr -> float -> M.arr
        and type step_output = (M.arr * M.arr) * float
-       and type output = M.arr * M.arr * M.arr)
+       and type solve_output = M.arr * M.arr * M.arr)
 
 
   let leapfrog_s (f : f_t) ~dt (xs, ps) t0 =
@@ -68,19 +68,19 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) = struct
 
   let leapfrog =
     (module struct
-      type s = M.arr * M.arr
-      type t = M.arr
+      type state = M.arr * M.arr
+      type f = M.arr * M.arr -> float -> M.arr
       type step_output = (M.arr * M.arr) * float
-      type output = M.arr * M.arr * M.arr
+      type solve_output = M.arr * M.arr * M.arr
 
       let step = leapfrog_s
       let solve = prepare step
     end
-    : SolverT
-      with type s = M.arr * M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr * M.arr
+       and type f = M.arr * M.arr -> float -> M.arr
        and type step_output = (M.arr * M.arr) * float
-       and type output = M.arr * M.arr * M.arr)
+       and type solve_output = M.arr * M.arr * M.arr)
 
 
   (* For the values used in the implementations below
@@ -115,57 +115,57 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) = struct
 
   let pseudoleapfrog =
     (module struct
-      type s = M.arr * M.arr
-      type t = M.arr
+      type state = M.arr * M.arr
+      type f = M.arr * M.arr -> float -> M.arr
       type step_output = (M.arr * M.arr) * float
-      type output = M.arr * M.arr * M.arr
+      type solve_output = M.arr * M.arr * M.arr
 
       let step = pseudoleapfrog_s
       let solve = prepare step
     end
-    : SolverT
-      with type s = M.arr * M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr * M.arr
+       and type f = M.arr * M.arr -> float -> M.arr
        and type step_output = (M.arr * M.arr) * float
-       and type output = M.arr * M.arr * M.arr)
+       and type solve_output = M.arr * M.arr * M.arr)
 
 
   let ruth3_s f ~dt = symint ~coeffs:ruth3_c f ~dt
 
   let ruth3 =
     (module struct
-      type s = M.arr * M.arr
-      type t = M.arr
+      type state = M.arr * M.arr
+      type f = M.arr * M.arr -> float -> M.arr
       type step_output = (M.arr * M.arr) * float
-      type output = M.arr * M.arr * M.arr
+      type solve_output = M.arr * M.arr * M.arr
 
       let step = ruth3_s
       let solve = prepare step
     end
-    : SolverT
-      with type s = M.arr * M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr * M.arr
+       and type f = M.arr * M.arr -> float -> M.arr
        and type step_output = (M.arr * M.arr) * float
-       and type output = M.arr * M.arr * M.arr)
+       and type solve_output = M.arr * M.arr * M.arr)
 
 
   let ruth4_s f ~dt = symint ~coeffs:ruth4_c f ~dt
 
   let ruth4 =
     (module struct
-      type s = M.arr * M.arr
-      type t = M.arr
+      type state = M.arr * M.arr
+      type f = M.arr * M.arr -> float -> M.arr
       type step_output = (M.arr * M.arr) * float
-      type output = M.arr * M.arr * M.arr
+      type solve_output = M.arr * M.arr * M.arr
 
       let step = ruth4_s
       let solve = prepare step
     end
-    : SolverT
-      with type s = M.arr * M.arr
-       and type t = M.arr
+    : Solver
+      with type state = M.arr * M.arr
+       and type f = M.arr * M.arr -> float -> M.arr
        and type step_output = (M.arr * M.arr) * float
-       and type output = M.arr * M.arr * M.arr)
+       and type solve_output = M.arr * M.arr * M.arr)
 
 
   (*

--- a/src/ode/symplectic/symplectic_generic.mli
+++ b/src/ode/symplectic/symplectic_generic.mli
@@ -34,44 +34,44 @@ module Make (M : Owl_types_ndarray_algodiff.Sig with type elt = float) : sig
     :  ('a -> dt:float -> M.arr * M.arr -> float -> (M.arr * M.arr) * float)
     -> 'a
     -> M.arr * M.arr
-    -> tspec_t
+    -> tspec
     -> unit
     -> M.arr * M.arr * M.arr
 
   val symplectic_euler
-    : (module Types.SolverT
-         with type s = M.arr * M.arr
-          and type t = M.arr
+    : (module Types.Solver
+         with type state = M.arr * M.arr
+          and type f = M.arr * M.arr -> float -> M.arr
           and type step_output = (M.arr * M.arr) * float
-          and type output = M.arr * M.arr * M.arr)
+          and type solve_output = M.arr * M.arr * M.arr)
 
   val leapfrog
-    : (module Types.SolverT
-         with type s = M.arr * M.arr
-          and type t = M.arr
+    : (module Types.Solver
+         with type state = M.arr * M.arr
+          and type f = M.arr * M.arr -> float -> M.arr
           and type step_output = (M.arr * M.arr) * float
-          and type output = M.arr * M.arr * M.arr)
+          and type solve_output = M.arr * M.arr * M.arr)
 
   val pseudoleapfrog
-    : (module Types.SolverT
-         with type s = M.arr * M.arr
-          and type t = M.arr
+    : (module Types.Solver
+         with type state = M.arr * M.arr
+          and type f = M.arr * M.arr -> float -> M.arr
           and type step_output = (M.arr * M.arr) * float
-          and type output = M.arr * M.arr * M.arr)
+          and type solve_output = M.arr * M.arr * M.arr)
 
   val ruth3
-    : (module Types.SolverT
-         with type s = M.arr * M.arr
-          and type t = M.arr
+    : (module Types.Solver
+         with type state = M.arr * M.arr
+          and type f = M.arr * M.arr -> float -> M.arr
           and type step_output = (M.arr * M.arr) * float
-          and type output = M.arr * M.arr * M.arr)
+          and type solve_output = M.arr * M.arr * M.arr)
 
   val ruth4
-    : (module Types.SolverT
-         with type s = M.arr * M.arr
-          and type t = M.arr
+    : (module Types.Solver
+         with type state = M.arr * M.arr
+          and type f = M.arr * M.arr -> float -> M.arr
           and type step_output = (M.arr * M.arr) * float
-          and type output = M.arr * M.arr * M.arr)
+          and type solve_output = M.arr * M.arr * M.arr)
 
   (* ----- helper functions ----- *)
 

--- a/src/ode/symplectic/symplectic_s.ml
+++ b/src/ode/symplectic/symplectic_s.ml
@@ -11,50 +11,50 @@ type mat = Owl_dense_matrix_s.mat
 include Symplectic_generic.Make (Owl_dense_ndarray.S)
 
 module Symplectic_Euler = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = symplectic_euler_s
   let solve = prepare step
 end
 
 module PseudoLeapfrog = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = pseudoleapfrog_s
   let solve = prepare step
 end
 
 module Leapfrog = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = leapfrog_s
   let solve = prepare step
 end
 
 module Ruth3 = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = ruth3_s
   let solve = prepare step
 end
 
 module Ruth4 = struct
-  type s = mat * mat
-  type t = mat
+  type state = mat * mat
+  type f = mat * mat -> float -> mat
   type step_output = (mat * mat) * float
-  type output = mat * mat * mat
+  type solve_output = mat * mat * mat
 
   let step = ruth4_s
   let solve = prepare step

--- a/src/ode/symplectic/symplectic_s.mli
+++ b/src/ode/symplectic/symplectic_s.mli
@@ -9,74 +9,74 @@
 type mat = Owl_dense_matrix_s.mat
 
 module Symplectic_Euler :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 module PseudoLeapfrog :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 module Leapfrog :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 module Ruth3 :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 module Ruth4 :
-  Types.SolverT
-  with type s = mat * mat
-   and type t = mat
+  Types.Solver
+  with type state = mat * mat
+   and type f = mat * mat -> float -> mat
    and type step_output = (mat * mat) * float
-   and type output = mat * mat * mat
+   and type solve_output = mat * mat * mat
 
 val symplectic_euler
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 val leapfrog
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 val pseudoleapfrog
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 val ruth3
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 val ruth4
-  : (module Types.SolverT
-       with type s = mat * mat
-        and type t = mat
+  : (module Types.Solver
+       with type state = mat * mat
+        and type f = mat * mat -> float -> mat
         and type step_output = (mat * mat) * float
-        and type output = mat * mat * mat)
+        and type solve_output = mat * mat * mat)
 
 (* ----- helper function ----- *)
 

--- a/src/ode/types.ml
+++ b/src/ode/types.ml
@@ -10,7 +10,7 @@
     Owl_ode ODEs integrators. *)
 
 (** Time specification for the ODE solvers. *)
-type tspec_t =
+type tspec =
   | T1 of { t0 : float; duration : float; dt : float }
       (** The [T1] constructor allow to specify the initial
       and final integration time, in the sense that the
@@ -30,7 +30,7 @@ type tspec_t =
       and may change or disappear in the future. *)
 
 (** Any solver compatible with {!Owl_ode.Ode.odeint}
-    has to comply with the SolverT type. You can use this
+    has to comply with the Solver type. You can use this
     to define completely new solvers, as done in the
     owl-ode-sundials or ocaml-cviode libraries, or
     to customize pre-existing solvers (see the
@@ -50,17 +50,16 @@ type tspec_t =
     {!Owl_ode.Symplectic_generic} can also be used in conjunction
     with jsoo, although how to do that is currently undocumented. 
 *)
-module type SolverT = sig
-  (** [s] is the type of the state (and thus also of
+module type Solver = sig
+  (** [state] is the type of the state (and thus also of
        the initial condition) provided to {!Owl_ode.Ode.odeint}.
        For example {!Owl.Mat.mat}. *)
-  type s
+  type state
 
-  (** [t] is type of the output of the evolution function
-      [f: s-> float ->t]. For example, in the case of 
-      sympletic solvers, [type s = Owl.Mat.(mat*mat)] and
-      [type t = Owl.Mat.mat]. *)
-  type t
+  (** [f] is type of the evolution function. For example, in the case of 
+      sympletic solvers, [type state = Owl.Mat.(mat*mat)] and
+      [type f = state -> float -> Owl.Mat.mat]. *)
+  type f
 
   (** [step_output] defines the type of the output of {!Owl_ode.Ode.step}.
       For example, in the case of native adaptive solvers,
@@ -69,18 +68,18 @@ module type SolverT = sig
       t1, dt, and whether this step was valid *)
   type step_output
 
-  (** [output] defines the type of the output of {!Owl_ode.Ode.odeint}.
+  (** [solve_output] defines the type of the output of {!Owl_ode.Ode.odeint}.
       For example, in the case of sympletc solvers,
       [type output = Owl.Mat.(mat * mat * mat)], corresponds
       to matrices that contain respectively the time,
       position, and momentum coordinates of the
       integrated solution *)
-  type output
+  type solve_output
 
   (** [step f dt y0 t0 ()] solves for one step given dt, y0, t0
       and the evolution function. Several such functions have already been
       implemented in this library and can be used as reference. *)
-  val step : (s -> float -> t) -> dt:float -> s -> float -> step_output
+  val step : f -> dt:float -> state -> float -> step_output
 
   (** [solve f y0 tspec ()] solves the initial value problem
 
@@ -91,5 +90,5 @@ module type SolverT = sig
       temporal specification tspec, and returns the desired outputs
       of type output. Several such functions have already been
       implemented in this library and can be used as reference. *)
-  val solve : (s -> float -> t) -> s -> tspec_t -> unit -> output
+  val solve : f -> state -> tspec -> unit -> solve_output
 end

--- a/src/sundials/owl_ode_sundials.ml
+++ b/src/sundials/owl_ode_sundials.ml
@@ -110,26 +110,26 @@ let cvode_s'
 
 let cvode ~stiff ~relative_tol ~abs_tol =
   (module struct
-    type s = Mat.mat
-    type t = Mat.mat
+    type state = Mat.mat
+    type f = Mat.mat -> float -> Mat.mat
     type step_output = Mat.mat * float
-    type output = Mat.mat * Mat.mat
+    type solve_output = Mat.mat * Mat.mat
 
     let step = cvode_s ~stiff ~relative_tol ~abs_tol
     let solve = integrate (cvode_s' ~stiff ~relative_tol ~abs_tol)
   end
-  : SolverT
-    with type s = Owl.Mat.mat
-     and type t = Owl.Mat.mat
+  : Solver
+    with type state = Owl.Mat.mat
+     and type f = Owl.Mat.mat -> float -> Owl.Mat.mat
      and type step_output = Owl.Mat.mat * float
-     and type output = Owl.Mat.mat * Owl.Mat.mat)
+     and type solve_output = Owl.Mat.mat * Owl.Mat.mat)
 
 
 module Owl_Cvode = struct
-  type s = Mat.mat
-  type t = Mat.mat
+  type state = Mat.mat
+  type f = Mat.mat -> float -> Mat.mat
   type step_output = Mat.mat * float
-  type output = Mat.mat * Mat.mat
+  type solve_output = Mat.mat * Mat.mat
 
   let stiff = false
   let relative_tol = 1E-4
@@ -139,10 +139,10 @@ module Owl_Cvode = struct
 end
 
 module Owl_Cvode_Stiff = struct
-  type s = Mat.mat
-  type t = Mat.mat
+  type state = Mat.mat
+  type f = Mat.mat -> float -> Mat.mat
   type step_output = Mat.mat * float
-  type output = Mat.mat * Mat.mat
+  type solve_output = Mat.mat * Mat.mat
 
   let stiff = true
   let relative_tol = 1E-4

--- a/src/sundials/owl_ode_sundials.mli
+++ b/src/sundials/owl_ode_sundials.mli
@@ -11,20 +11,22 @@ val cvode
   :  stiff:bool
   -> relative_tol:float
   -> abs_tol:float
-  -> (module Owl_ode.Types.SolverT
-        with type s = Owl.Mat.mat
-         and type t = Owl.Mat.mat
+  -> (module Owl_ode.Types.Solver
+        with type state = Owl.Mat.mat
+         and type f = Owl.Mat.mat -> float -> Owl.Mat.mat
          and type step_output = Owl.Mat.mat * float
-         and type output = Owl.Mat.mat * Owl.Mat.mat)
+         and type solve_output = Owl.Mat.mat * Owl.Mat.mat)
 
 module Owl_Cvode :
-  Owl_ode.Types.SolverT
-  with type s = Owl.Mat.mat
-   and type t = Owl.Mat.mat
-   and type output = Owl.Mat.mat * Owl.Mat.mat
+  Owl_ode.Types.Solver
+  with type state = Owl.Mat.mat
+   and type f = Owl.Mat.mat -> float -> Owl.Mat.mat
+   and type step_output = Owl.Mat.mat * float
+   and type solve_output = Owl.Mat.mat * Owl.Mat.mat
 
 module Owl_Cvode_Stiff :
-  Owl_ode.Types.SolverT
-  with type s = Owl.Mat.mat
-   and type t = Owl.Mat.mat
-   and type output = Owl.Mat.mat * Owl.Mat.mat
+  Owl_ode.Types.Solver
+  with type state = Owl.Mat.mat
+   and type f = Owl.Mat.mat -> float -> Owl.Mat.mat
+   and type step_output = Owl.Mat.mat * float
+   and type solve_output = Owl.Mat.mat * Owl.Mat.mat


### PR DESCRIPTION
I'm proposing name changes for several types to improve readability, and in some cases, for simplicity. 
This includes:

`type s` --> `type state`
`type output` --> `type solve_output`
`type tspec_t` --> `type tspec`
`module type SolverT` --> `module type Solver`
`type step_output` unchanged

Also, I'm proposing that we constrain the type of the evolution function `f` as opposed to its output `t`.
So instead of having, `type t = Mat.mat` we have type `type f = Mat.mat -> float -> Mat.mat` in native solvers such as RK4. I think this is more general and might be useful if we want to consider evolution functions that are not simply of type `state -> float -> t`. I'm thinking of cases that involves Algodiff types.

I would be curious to hear what you guys think @mseri @ryanrhymes @ghennequin, possibly more intuitive type names or if you prefer the old ones.
