### PR TITLE
Arr integration

### DIFF
--- a/owl-ode-base.opam
+++ b/owl-ode-base.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0.0"}
-  "owl-base"
+  "owl-base" {>= "0.7.0"}
 ]
 synopsis: "Owl's ODE solvers"
 description: """OwlDE: ODE Integration library

--- a/owl-ode-odepack.opam
+++ b/owl-ode-odepack.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "owl" {>= "0.6.0"}
+  "owl" {>= "0.7.0"}
   "dune" {>= "2.0.0"}
   "owl-ode" {= version}
   "owl-plplot" {with-test}

--- a/owl-ode-sundials.opam
+++ b/owl-ode-sundials.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "owl" {>= "0.6.0"}
+  "owl" {>= "0.7.0"}
   "dune" {>= "2.0.0"}
   "owl-ode" {= version}
   "owl-plplot" {with-test}

--- a/owl-ode.opam
+++ b/owl-ode.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0.0"}
-  "owl" {>= "0.6.0"}
+  "owl" {>= "0.7.0"}
   "owl-ode-base" {= version}
   "owl-plplot" {with-test}
   "alcotest" {with-test}

--- a/src/ode/owl_ode.ml
+++ b/src/ode/owl_ode.ml
@@ -3,3 +3,4 @@ module Ode = Owl_ode_base.Ode
 module Types = Owl_ode_base.Types
 module Native = Native
 module Symplectic = Symplectic
+include Types

--- a/src/ode/owl_ode.ml
+++ b/src/ode/owl_ode.ml
@@ -3,3 +3,5 @@ module Ode = Owl_ode_base.Ode
 module Types = Owl_ode_base.Types
 module Native = Native
 module Symplectic = Symplectic
+
+include Types

--- a/src/ode/owl_ode.ml
+++ b/src/ode/owl_ode.ml
@@ -3,4 +3,3 @@ module Ode = Owl_ode_base.Ode
 module Types = Owl_ode_base.Types
 module Native = Native
 module Symplectic = Symplectic
-include Types

--- a/src/ode/owl_ode.mli
+++ b/src/ode/owl_ode.mli
@@ -1,0 +1,68 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * OWL-ODE - Ordinary Differential Equation Solvers
+ *
+ * Copyright (c) 2019 Ta-Chu Kao <tck29@cam.ac.uk>
+ * Copyright (c) 2019 Marcello Seri <m.seri@rug.nl>
+ *)
+
+module Types : module type of Owl_ode_base.Types
+module Common : module type of Owl_ode_base.Common
+module Ode : module type of Owl_ode_base.Ode
+module Native : module type of Native
+module Symplectic : module type of Symplectic
+
+
+(** The Types module provides some common types for 
+    Owl_ode ODEs integrators. It is included in this module for convenience.
+    *)
+
+(** Time specification for the ODE solvers. *)
+type tspec = Types.tspec =
+  | T1 of
+      { t0 : float
+      ; duration : float
+      ; dt : float
+      }
+      (** The [T1] constructor allow to specify the initial
+      and final integration time, in the sense that the
+      solver starts with t=t0 and integrates until it
+      reaches t=t0+duration, and the timestep dt. 
+      This last parameter is ignored by the adaptive
+      methods. *)
+  | T2 of
+      { tspan : float * float
+      ; dt : float
+      }
+      (** The [T2] constructor allow to specify a tuple 
+      (t0, tf) of the initial and final integration
+      time, in the sense that the solver starts with
+      t=t0 and integrates until it reaches t=tf, and
+      the timestep dt. This last parameter is ignored
+      by the adaptive methods. *)
+  | T3 of float array
+      (** The [T3] constructor is currently unsupported
+      and may change or disappear in the future. *)
+
+(** Any solver compatible with {!Owl_ode_base.Ode.odeint}
+    has to comply with the Solver type. You can use this
+    to define completely new solvers, as done in the
+    owl-ode-sundials, owl-ode-odepack or ocaml-cviode
+    libraries, or to customize pre-existing solvers (see
+    the van_der_pol example for one such cases). 
+
+    The native ocaml solvers provided by {!Owl_ode_base} in both single and
+    double precision can be found in {!Owl_ode_base.Native}, respectively
+    in the {!Owl_ode_base.Native.S} and {!Owl_ode_base.Native.D} modules. These
+    provide multiple single-step and adaptive implementations.
+
+    Symplectic solvers for separable Hamiltonian systems are also
+    available and can be found in {!Owl_ode_base.Symplectic.S} and
+    {!Owl_ode_base.Symplectic.D}. Refer to the damped oscillator for an
+    example of use.
+
+    The generic solvers in {!Owl_ode_base.Native_generic} and in
+    {!Owl_ode_base.Symplectic_generic} can also be used in conjunction
+    with jsoo, although how to do that is currently undocumented. 
+*)
+module type Solver = Types.Solver

--- a/src/sundials/owl_ode_sundials.ml
+++ b/src/sundials/owl_ode_sundials.ml
@@ -31,9 +31,11 @@ let make_cvode_session
   let tolerances = Cvode.(SStolerances (relative_tol, abs_tol)) in
   (* make a copy of y0 so we don't overwrite it*)
   let y0 = Arr.copy y0 in
+  let s = Arr.shape y0 in
   (* rhs function that sundials understands *)
   let f_wrapped t y yd =
     let y = unwrap y in
+    let y = Arr.reshape y s in
     let dy = f y t in
     Array1.blit (wrap dy) yd
   in
@@ -46,7 +48,7 @@ let make_cvode_session
   , y )
 
 
-let cvode_s ~stiff ~relative_tol ~abs_tol (f : Mat.mat -> float -> Mat.mat) ~dt y0 t0 =
+let cvode_s ~stiff ~relative_tol ~abs_tol (f : Arr.arr -> float -> Arr.arr) ~dt y0 t0 =
   let s = Arr.shape y0 in
   let session, yvec, y = make_cvode_session ~stiff ~relative_tol ~abs_tol f y0 t0 in
   let t1 = t0 +. dt in
@@ -97,25 +99,25 @@ let cvode_s'
 
 let cvode ~stiff ~relative_tol ~abs_tol =
   (module struct
-    type state = Mat.mat
-    type f = Mat.mat -> float -> Mat.mat
-    type step_output = Mat.mat * float
-    type solve_output = Mat.mat * Mat.mat
+    type state = Arr.arr
+    type f = Arr.arr -> float -> Arr.arr
+    type step_output = Arr.arr * float
+    type solve_output = Arr.arr * Arr.arr
 
     let step = cvode_s ~stiff ~relative_tol ~abs_tol
     let solve = integrate (cvode_s' ~stiff ~relative_tol ~abs_tol)
   end : Solver
-    with type state = Owl.Mat.mat
-     and type f = Owl.Mat.mat -> float -> Owl.Mat.mat
-     and type step_output = Owl.Mat.mat * float
-     and type solve_output = Owl.Mat.mat * Owl.Mat.mat)
+    with type state = Arr.arr
+     and type f = Arr.arr -> float -> Arr.arr
+     and type step_output = Arr.arr * float
+     and type solve_output = Arr.arr * Arr.arr)
 
 
 module Owl_Cvode = struct
-  type state = Mat.mat
-  type f = Mat.mat -> float -> Mat.mat
-  type step_output = Mat.mat * float
-  type solve_output = Mat.mat * Mat.mat
+  type state = Arr.arr
+  type f = Arr.arr -> float -> Arr.arr
+  type step_output = Arr.arr * float
+  type solve_output = Arr.arr * Arr.arr
 
   let stiff = false
   let relative_tol = 1E-4
@@ -125,10 +127,10 @@ module Owl_Cvode = struct
 end
 
 module Owl_Cvode_Stiff = struct
-  type state = Mat.mat
-  type f = Mat.mat -> float -> Mat.mat
-  type step_output = Mat.mat * float
-  type solve_output = Mat.mat * Mat.mat
+  type state = Arr.arr
+  type f = Arr.arr -> float -> Arr.arr
+  type step_output = Arr.arr * float
+  type solve_output = Arr.arr * Arr.arr
 
   let stiff = true
   let relative_tol = 1E-4

--- a/src/sundials/owl_ode_sundials.mli
+++ b/src/sundials/owl_ode_sundials.mli
@@ -3,8 +3,7 @@ val wrap
   -> (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 val unwrap
-  :  int * int
-  -> (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
+  :  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
   -> Owl.Mat.mat
 
 val cvode

--- a/src/sundials/owl_ode_sundials.mli
+++ b/src/sundials/owl_ode_sundials.mli
@@ -1,31 +1,31 @@
 val wrap
-  :  Owl.Mat.mat
+  :  Owl.Arr.arr
   -> (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 val unwrap
   :  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
-  -> Owl.Mat.mat
+  -> Owl.Arr.arr
 
 val cvode
   :  stiff:bool
   -> relative_tol:float
   -> abs_tol:float
   -> (module Owl_ode.Types.Solver
-        with type state = Owl.Mat.mat
-         and type f = Owl.Mat.mat -> float -> Owl.Mat.mat
-         and type step_output = Owl.Mat.mat * float
-         and type solve_output = Owl.Mat.mat * Owl.Mat.mat)
+        with type state = Owl.Arr.arr
+         and type f = Owl.Arr.arr -> float -> Owl.Arr.arr
+         and type step_output = Owl.Arr.arr * float
+         and type solve_output = Owl.Arr.arr * Owl.Arr.arr)
 
 module Owl_Cvode :
   Owl_ode.Types.Solver
-    with type state = Owl.Mat.mat
-     and type f = Owl.Mat.mat -> float -> Owl.Mat.mat
-     and type step_output = Owl.Mat.mat * float
-     and type solve_output = Owl.Mat.mat * Owl.Mat.mat
+    with type state = Owl.Arr.arr
+     and type f = Owl.Arr.arr -> float -> Owl.Arr.arr
+     and type step_output = Owl.Arr.arr * float
+     and type solve_output = Owl.Arr.arr * Owl.Arr.arr
 
 module Owl_Cvode_Stiff :
   Owl_ode.Types.Solver
-    with type state = Owl.Mat.mat
-     and type f = Owl.Mat.mat -> float -> Owl.Mat.mat
-     and type step_output = Owl.Mat.mat * float
-     and type solve_output = Owl.Mat.mat * Owl.Mat.mat
+    with type state = Owl.Arr.arr
+     and type f = Owl.Arr.arr -> float -> Owl.Arr.arr
+     and type step_output = Owl.Arr.arr * float
+     and type solve_output = Owl.Arr.arr * Owl.Arr.arr


### PR DESCRIPTION
1. allow users to integrate Ndarrays of dimension n. the results is an Ndarray of dimension (n+1), where the first dimension corresponds to time
2. expose type `tspec` and `Solver` directly in `Owl_ode` 